### PR TITLE
Fix the delegate message handlers returning the same hash code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ env:
 
 on:
   push:
-    branches: [ develop, main, feature/* ]
+    branches: [ develop, main, feature/*, bugfix/* ]
   pull_request:
     branches: [ develop, main ]
 

--- a/src/Axon/ConcurrentHashSet.cs
+++ b/src/Axon/ConcurrentHashSet.cs
@@ -19,6 +19,7 @@ using System.Diagnostics.CodeAnalysis;
 /// concurrently from multiple threads.
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
+[ExcludeFromCodeCoverage]
 [SuppressMessage("ReSharper", "SA1405:DebugAssertMustProvideMessageText", Justification = "Library")]
 internal class ConcurrentHashSet<T> : IReadOnlyCollection<T>, ICollection<T>
 {

--- a/src/Axon/Messaging/MessageHandlerCallback.cs
+++ b/src/Axon/Messaging/MessageHandlerCallback.cs
@@ -1,5 +1,7 @@
 namespace Axon.Messaging;
 
+using System.Diagnostics.CodeAnalysis;
+
 /// <summary>
 /// The message handler callback.
 /// </summary>
@@ -8,3 +10,20 @@ namespace Axon.Messaging;
 /// <returns>A <see cref="Task"/> containing the result of the message processing.</returns>
 public delegate Task<object?> MessageHandlerCallback<in TMessage>(TMessage message)
     where TMessage : IMessage<object>;
+
+/// <summary>
+/// The message handler extensions.
+/// </summary>
+[SuppressMessage("ReSharper", "SA1649:FileNameMustMatchTypeName", Justification = "Delegate extensions")]
+internal static class MessageHandlerCallback
+{
+    /// <summary>
+    /// Wraps the <see cref="MessageHandlerCallback"/> delegate inside a
+    /// <see cref="WrappedMessageHandlerCallback{TMessage}"/> instance.
+    /// </summary>
+    /// <param name="handlerCallback">The <see cref="MessageHandlerCallback"/> delegate.</param>
+    /// <typeparam name="TMessage">The message type.</typeparam>
+    /// <returns>A <see cref="WrappedMessageHandlerCallback{TMessage}"/>.</returns>
+    public static IMessageHandler<TMessage> Wrap<TMessage>(this MessageHandlerCallback<TMessage> handlerCallback)
+        where TMessage : IMessage<object> => new WrappedMessageHandlerCallback<TMessage>(handlerCallback);
+}

--- a/src/Axon/MulticastDelegateExtensions.cs
+++ b/src/Axon/MulticastDelegateExtensions.cs
@@ -1,0 +1,34 @@
+namespace Axon;
+
+/// <summary>
+/// MulticastDelegate extensions.
+/// </summary>
+public static class MulticastDelegateExtensions
+{
+    /// <summary>
+    /// Returns a hash for a <see cref="MulticastDelegate"/>.
+    /// <para/>
+    /// The method iterates through each delegate in the invocation list using a foreach loop, and XORs the hash code of
+    /// the method and the target of each delegate with the running total hash code. This ensures that any two distinct
+    /// action delegates will have different hash codes, even if they have the same method and target.
+    /// <para />
+    /// IMPORTANT: As with any hash function, hash codes are not guaranteed to be unique and a collision can occur.
+    /// However, this method should provide a good starting point for generating unique hash codes for action delegates.
+    /// </summary>
+    /// <param name="delegate">The <see cref="MulticastDelegate"/>.</param>
+    /// <returns>The hash value.</returns>
+    public static int GetMulticastDelegateHashCode(this MulticastDelegate @delegate)
+    {
+        var hash = @delegate.GetType().GetHashCode();
+        foreach (var d in @delegate.GetInvocationList())
+        {
+            hash ^= d.Method.GetHashCode();
+            if (d.Target is not null)
+            {
+                hash ^= d.Target.GetHashCode();
+            }
+        }
+
+        return hash;
+    }
+}

--- a/src/Axon/WrappedMessageHandlerCallback.cs
+++ b/src/Axon/WrappedMessageHandlerCallback.cs
@@ -77,5 +77,5 @@ internal class WrappedMessageHandlerCallback<TMessage> : IMessageHandler<TMessag
     }
 
     /// <inheritdoc />
-    public override int GetHashCode() => this.callback.GetHashCode();
+    public override int GetHashCode() => this.callback.GetMulticastDelegateHashCode();
 }

--- a/test/Axon.Tests/Axon.Tests.csproj
+++ b/test/Axon.Tests/Axon.Tests.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Axon.Tests/Axon.Tests.csproj
+++ b/test/Axon.Tests/Axon.Tests.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Axon.Tests/WrappedMessageHandlerCallbackTest.cs
+++ b/test/Axon.Tests/WrappedMessageHandlerCallbackTest.cs
@@ -1,0 +1,22 @@
+namespace Axon;
+
+using Axon.Messaging;
+
+public class WrappedMessageHandlerCallbackTest
+{
+    [Fact]
+    public void GetHashCode_Should_ReturnUniqueValue()
+    {
+        // Arrange
+        MessageHandlerCallback<IMessage<object>> handler1 = message => Task.FromResult<object?>("Hello");
+        MessageHandlerCallback<IMessage<object>> handler2 = message => Task.FromResult<object?>("Hello");
+
+        var wrappedHandler1 = new WrappedMessageHandlerCallback<IMessage<object>>(handler1);
+        var wrappedHandler2 = new WrappedMessageHandlerCallback<IMessage<object>>(handler2);
+
+        // Assert
+        Assert.Equal(handler1.GetHashCode(), handler2.GetHashCode());
+        Assert.NotEqual(handler1.GetMulticastDelegateHashCode(), handler2.GetMulticastDelegateHashCode());
+        Assert.NotEqual(wrappedHandler1.GetHashCode(), wrappedHandler2.GetHashCode());
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,12 +3,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
🪲 Bug Fixes

- `GetHashCode()` method on `MulticastDelegate` of the same type returns the same hash code. This change adds an extension method `MulticastDelegate.GetMulticastDelegateHashCode()` to calculate the hash code by iterating through its invocation list.